### PR TITLE
Removing .keys() calls.

### DIFF
--- a/src/configurator.py
+++ b/src/configurator.py
@@ -45,7 +45,7 @@ class Configuration(object):
             os.chmod(CONFIG_FILE, 0o600)
 
     def has(self, key):
-        return key in self.params.keys()
+        return key in self.params
 
     def get(self, key):
         try:
@@ -91,6 +91,6 @@ class Configuration(object):
 
     def __str__(self):
         ans = ''
-        for key in sorted(self.params.keys()):
+        for key in sorted(self.params):
             ans += '{0}: {1}\n'.format(key, self.params[key])
         return ans

--- a/src/indicator.py
+++ b/src/indicator.py
@@ -144,15 +144,15 @@ class Indicator(object):
         keys = []
         for day in stats:
             days.append(day)
-            if 'distance' in stats[day].keys():
+            if 'distance' in stats[day]:
                 distance.append(stats[day]['distance']/1000.0)
             else:
                 distance.append(0)
-            if 'clics' in stats[day].keys():
+            if 'clics' in stats[day]:
                 clics.append(stats[day]['clics'])
             else:
                 clics.append(0)
-            if 'keys' in stats[day].keys():
+            if 'keys' in stats[day]:
                 keys.append(stats[day]['keys'])
             else:
                 keys.append(0)

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -55,7 +55,7 @@ class Monitor(Thread):
         day = time.strftime('%Y-%m-%d', time.localtime())
         configuration = Configuration()
         stats = configuration.get('stats')
-        if day in stats.keys():
+        if day in stats:
             self.data[day] = stats[day]
 
         # Check if the extension is present
@@ -95,7 +95,7 @@ class Monitor(Thread):
     def save(self):
         configuration = Configuration()
         stats = configuration.get('stats')
-        for day in self.data.keys():
+        for day in self.data:
             stats[day] = self.data[day]
         configuration.set('stats', stats)
         configuration.save()
@@ -141,21 +141,21 @@ class Monitor(Thread):
 
     def set_data(self, key, value):
         day = time.strftime('%Y-%m-%d', time.localtime())
-        if day not in self.data.keys():
+        if day not in self.data:
             self.data.keys = {}
         self.data[day][key] = value
 
     def inc_data(self, key, value):
         day = time.strftime('%Y-%m-%d', time.localtime())
-        if day not in self.data.keys():
+        if day not in self.data:
             self.data[day] = {}
-        if key not in self.data[day].keys():
+        if key not in self.data[day]:
             self.data[day][key] = 0
         self.data[day][key] += value
 
     def get_data(self, key):
         day = time.strftime('%Y-%m-%d', time.localtime())
-        if day in self.data.keys():
+        if day in self.data:
             if key in self.data[day].keys:
                 return self.data[day][key]
         return 0


### PR DESCRIPTION
Using `.keys()` is  bit slower than just call variable directly. Default behavior of dict in a loop is return  key, so we don't need to use `.keys()` :)

Reference: [Why use dict.keys?](https://stackoverflow.com/a/17634287/5314295)